### PR TITLE
fixed backwards sorted query bug

### DIFF
--- a/heatflask.py
+++ b/heatflask.py
@@ -506,7 +506,6 @@ def group_stream(username, activity_id):
             pool.join()
             out_queue.put(None)
             out_queue.put(StopIteration)
-
     user = Users.get(username)
     pool = gevent.pool.Pool(app.config.get("CONCURRENCY"))
     out_queue = gevent.queue.Queue()
@@ -514,7 +513,6 @@ def group_stream(username, activity_id):
     gevent.sleep(0)
     return Response((sse_out(a) if a else sse_out() for a in out_queue),
                     mimetype='text/event-stream')
-
 
 @app.route('/<username>/activities')
 @log_request_event
@@ -600,6 +598,7 @@ def data_socket(ws):
         msg = receiveObj(ws)
         if msg:
             if "query" in msg:
+                # log.debug("Received query: {}".format(msg["query"]))
                 # sendObj(ws, {"msg": "sending query {}...".format(msg["query"])})
                 for a in Activities.query(msg["query"]):
                     sendObj(ws, a)

--- a/models.py
+++ b/models.py
@@ -383,7 +383,7 @@ class Users(UserMixin, db_sql.Model):
         gevent.sleep(0)
         return out_queue
 
-    def query_activities(self, 
+    def query_activities(self,
                          activity_ids=None,
                          grouped=False,
                          exclude_ids=[],
@@ -902,9 +902,12 @@ class Index(object):
         to_delete = None
         if exclude_ids:
             try:
-                query_ids = set( int(doc["_id"]) 
-                    for doc in cls.db.find(query, {"_id": True}).limit(limit) )
-            except Exception as e: 
+                query_ids = set(int(doc["_id"]) 
+                    for doc in cls.db.find(
+                        query, {"_id": True}).sort("ts_UTC", pymongo.DESCENDING)
+                                             .limit(limit) )
+
+            except Exception as e:
                 log.exception(e)
                 return
             
@@ -933,7 +936,7 @@ class Index(object):
                 cursor = cls.db.find(query, out_fields)
             else:
                 cursor = cls.db.find(query)
-            cursor = cursor.limit(limit).sort("ts_UTC", pymongo.DESCENDING)
+            cursor = cursor.sort("ts_UTC", pymongo.DESCENDING).limit(limit)
 
         except Exception as e:
             log.error(
@@ -1193,8 +1196,7 @@ class Activities(object):
             queue.put(None)
             queue.put(StopIteration)
             # log.debug("done with query")
-
-        
+     
         gevent.spawn(go)
         gevent.sleep(0)
         return queue


### PR DESCRIPTION
This pull request fixes a bug where querying the last x activities would return the first x activities because it was sorted backwards.