### PR TITLE
Batch write on import

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,18 +63,15 @@ class Config(object):
     DAY = 24 * HOUR
     
     # How long we store an Index entry in MongoDB
-    STORE_INDEX_TIMEOUT = int(os.environ.get("INDEX_TTL", 10 * DAY))   # default 10 days
+    STORE_INDEX_TIMEOUT = int(os.environ.get("INDEX_TTL", 10 * DAY))
 
     # How long we store Activity stream data in MongoDB
-    STORE_ACTIVITIES_TIMEOUT = int(os.environ.get("DB_TTL", 5 * DAY))  # default 5 days
+    STORE_ACTIVITIES_TIMEOUT = int(os.environ.get("DB_TTL", 5 * DAY))
 
     # How long we Redis-cache Activity stream data
-    CACHE_ACTIVITIES_TIMEOUT = int(os.environ.get("CACHE_TTL", 8 * HOUR))  # default 8 hours
+    CACHE_ACTIVITIES_TIMEOUT = int(os.environ.get("CACHE_TTL", 8 * HOUR))
 
     CACHE_IP_INFO_TIMEOUT = 1 * 24 * 60 * 60  # 1 day
-
-    # How long we will allow data requests from the same identified client
-    WEB_CLIENT_ID_TIMEOUT = 10 * 60 * 60 * 24  # 10 days
 
     JSONIFY_PRETTYPRINT_REGULAR = True
 

--- a/heatflask/__init__.py
+++ b/heatflask/__init__.py
@@ -1,3 +1,6 @@
+from gevent import monkey
+monkey.patch_all()
+
 from datetime import datetime
 import os
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,9 +1,10 @@
 # wsgi.py
 #  this is run by gunicorn
+from datetime import timedelta
+import logging
 
 from heatflask import create_app
 # from signal import signal, SIGPIPE, SIG_DFL
-import logging
 
 app = create_app()
 
@@ -21,20 +22,26 @@ log.handlers = handlers
 log_level_name = app.config["LOG_LEVEL"]
 log_level = logging.getLevelName(log_level_name)
 log.setLevel(log_level)
-    
+
 loc_status = ""
 if app.config.get("OFFLINE"):
     loc_status = " OFFLINE"
 elif app.config.get("USE_REMOTE_DB"):
     loc_status = " USING REMOTE DATA-STORES"
 
-log.info(
-    "Heatflask server starting%s LOG_LEVEL=%s",
-    loc_status,
-    log_level_name
-)
+keys = {
+    "STORE_INDEX_TIMEOUT",
+    "STORE_ACTIVITIES_TIMEOUT",
+    "CACHE_ACTIVITIES_TIMEOUT"
+}
+ttls = {s: timedelta(seconds=app.config[s]) for s in keys}
 
-# log.info(app.config)
+log.info(
+    "Heatflask server starting%s LOG_LEVEL=%s: %s",
+    loc_status,
+    log_level_name,
+    ttls
+)
 
 # makes python ignore sigpipe and prevents broken pipe exception when client
 #  aborts an SSE stream by closing the browser window

--- a/wsgi.py
+++ b/wsgi.py
@@ -34,7 +34,7 @@ keys = {
     "STORE_ACTIVITIES_TIMEOUT",
     "CACHE_ACTIVITIES_TIMEOUT"
 }
-ttls = {s: timedelta(seconds=app.config[s]) for s in keys}
+ttls = {s: "{}".format(timedelta(seconds=app.config[s])) for s in keys}
 
 log.info(
     "Heatflask server starting%s LOG_LEVEL=%s: %s",


### PR DESCRIPTION
writes imported streams to redis cache and mongodb as batch operations.This is more efficient and probably reduces the number of mongo connections, which is a problem sometimes.
 